### PR TITLE
ENG-3975 Return bytes instead of str for py3 compatibility

### DIFF
--- a/tornado_botocore/__init__.py
+++ b/tornado_botocore/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = '1.5.0'
+__version__ = '1.5.0.1'
 
 try:
     from .base import Botocore

--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -142,10 +142,10 @@ class Botocore(object):
                 response_dict['body'] = http_response.body
             elif response_dict['status_code'] == 599:
                 # Timeout
-                response_dict['body'] = '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.RequestTimedOut</Code><Message>Connection timed out</Message><Detail/></Error></ErrorResponse>'
+                response_dict['body'] = b'<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.RequestTimedOut</Code><Message>Connection timed out</Message><Detail/></Error></ErrorResponse>'
             else:
                 # something else we don't know about
-                response_dict['body'] = '<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.UnkownError</Code><Message>Unknown Error</Message><Detail/></Error></ErrorResponse>'
+                response_dict['body'] = b'<?xml version="1.0"?><ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/"><Error><Type>Sender</Type><Code>AWS.SimpleQueueService.UnkownError</Code><Message>Unknown Error</Message><Detail/></Error></ErrorResponse>'
 
         elif operation_model.has_streaming_output:
             response_dict['body'] = botocore.response.StreamingBody(


### PR DESCRIPTION
Ticket: ENG-3975

#### Changes proposed:
Modified to use bytes instead of str when hardcoding response_dict['body']

#### Justification for inclusion in release:
- Prioritized item in sprint
- Production issue due to Python 3 upgrade

#### Deployment instructions:
N/A