### PR TITLE
Support streaming request bodies

### DIFF
--- a/tornado_botocore/__init__.py
+++ b/tornado_botocore/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = '1.5.0.1'
+__version__ = '1.5.0.2'
 
 try:
     from .base import Botocore

--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -86,7 +86,7 @@ class Botocore(object):
         req_body = getattr(request.body, 'buf', request.body)
         
         if hasattr(req_body, 'read') and type(getattr(req_body, 'read')) == types.MethodType:
-            req_body=  req_body.read()
+            req_body = req_body.read()
         
         request = HTTPRequest(
             url=request.url,

--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -1,5 +1,4 @@
 import logging
-import types
 
 from functools import partial
 try:

--- a/tornado_botocore/base.py
+++ b/tornado_botocore/base.py
@@ -85,7 +85,7 @@ class Botocore(object):
 
         req_body = getattr(request.body, 'buf', request.body)
         
-        if hasattr(req_body, 'read') and type(getattr(req_body, 'read')) == types.MethodType:
+        if hasattr(req_body, 'read') and callable(getattr(req_body, 'read')):
             req_body = req_body.read()
         
         request = HTTPRequest(


### PR DESCRIPTION
S3.PutObject and possibly other requests will create a `body` with type BytesIO. Prior to this change, this would throw an error when the Tornado HTTPRequest is created, as it expects bytes or string for the `body` argument.  
